### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@
 
 This project is part of the Model Context Protocol (MCP) ecosystem and provides tools to interact with external APIs and manage specific domain models. It is designed to demonstrate how to build an MCP server with external API integration and data validation.
 
+<a href="https://glama.ai/mcp/servers/@newerton/mcp-status-invest">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@newerton/mcp-status-invest/badge" alt="Status Invest Server MCP server" />
+</a>
+
 </div>
 
 ## Table of Contents


### PR DESCRIPTION
This PR adds a badge for the [Status Invest MCP Server](https://glama.ai/mcp/servers/@newerton/mcp-status-invest) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@newerton/mcp-status-invest">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@newerton/mcp-status-invest/badge" alt="Status Invest Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.